### PR TITLE
Update beta to production release

### DIFF
--- a/lib/ProjectModule/module.modulemap
+++ b/lib/ProjectModule/module.modulemap
@@ -1,4 +1,4 @@
 module CZitiPrivate {
-  header "../Ziti-Bridging-Header.h"
-  export *
+    header "../Ziti-Bridging-Header.h"
+    export *
 }

--- a/lib/Ziti.swift
+++ b/lib/Ziti.swift
@@ -16,7 +16,7 @@ limitations under the License.
 
 import Foundation
 import CZitiPrivate
- 
+
 /**
  This is the main entry point for interacting with Ziti, and provides a Swift-friendly way to access the Ziti C SDK
  


### PR DESCRIPTION
- Adds "Build for Distribution" for forward-compatibility
- Updates interfaces to remove any references to Ziti C SDK types
- Add CZitiPrivate module to allow (internal-only) access to Ziti C SDK methods and types