### PR TITLE
Bump TSDK to v0.21.5

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,13 +28,17 @@ jobs:
 
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '13.2.1'
+        xcode-version: '14.2.0'
+
+    - uses: lukka/run-vcpkg@v10
+      with:
+        vcpkgGitCommitId: '19af97cba8ca48474e4ad15a24ed50271a9ecdac'
 
     - name: ${{ matrix.spec.name }}
       env:
         TOOLCHAIN: ${{ matrix.spec.toolchain && format('../../toolchains/{0}.cmake', matrix.spec.toolchain) || '' }}
       run: |
-        cmake -DCMAKE_BUILD_TYPE=Release -DMBEDTLS_FATAL_WARNINGS:BOOL=OFF -DEXCLUDE_PROGRAMS=ON -DCMAKE_TOOLCHAIN_FILE="${TOOLCHAIN}" -S ./deps/ziti-tunnel-sdk-c -B ./deps/ziti-tunnel-sdk-c/${{ matrix.spec.name }}
+        cmake -DCMAKE_BUILD_TYPE=Release -DTLSUV_TLSLIB=mbedtls -DMBEDTLS_FATAL_WARNINGS:BOOL=OFF -DEXCLUDE_PROGRAMS=ON -DZITI_TUNNEL_BUILD_TESTS=OFF -DCMAKE_TOOLCHAIN_FILE="${TOOLCHAIN}" -S ./deps/ziti-tunnel-sdk-c -B ./deps/ziti-tunnel-sdk-c/${{ matrix.spec.name }}
         cmake --build ./deps/ziti-tunnel-sdk-c/${{ matrix.spec.name }}
         tar -cvzf ${{ matrix.spec.name }}.tgz -C ./deps/ziti-tunnel-sdk-c ${{ matrix.spec.name }}
 
@@ -56,7 +60,7 @@ jobs:
 
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '13.2.1'
+        xcode-version: '14.2.0'
 
     - name: Download Artifacts
       uses: actions/download-artifact@v3

--- a/CZiti.xcodeproj/project.pbxproj
+++ b/CZiti.xcodeproj/project.pbxproj
@@ -107,6 +107,8 @@
 		5AE14C8C2471DDA000179365 /* libCZiti.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5AB6DF68244B7C3C00F4B4E0 /* libCZiti.a */; };
 		5AF0C4112489987500CD4DAE /* ZitiClaims.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0C4102489987500CD4DAE /* ZitiClaims.swift */; };
 		5AF0C4122489987500CD4DAE /* ZitiClaims.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF0C4102489987500CD4DAE /* ZitiClaims.swift */; };
+		AA039EE02A963C53004D3F78 /* libllhttp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = AA039EDF2A963C53004D3F78 /* libllhttp.a */; };
+		AA039EE22A963C9C004D3F78 /* libllhttp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = AA039EE12A963C9C004D3F78 /* libllhttp.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -209,13 +211,10 @@
 		5AAAEDE32464D8AB00C56383 /* ziti-mac-enroller */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "ziti-mac-enroller"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5AAAEDE52464D8AB00C56383 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		5AB6DF68244B7C3C00F4B4E0 /* libCZiti.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libCZiti.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		5AB6DF77244B8F2000F4B4E0 /* libuv_mbed.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libuv_mbed.a; path = "deps/ziti-sdk-c/build-os-arch/deps/uv-mbed/libuv_mbed.a"; sourceTree = "<group>"; };
 		5AB6DF78244B8F2000F4B4E0 /* libmbedx509.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libmbedx509.a; path = "deps/ziti-sdk-c/build-os-arch/deps/uv-mbed/deps/mbedtls/library/libmbedx509.a"; sourceTree = "<group>"; };
 		5AB6DF79244B8F2000F4B4E0 /* libmbedcrypto.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libmbedcrypto.a; path = "deps/ziti-sdk-c/build-os-arch/deps/uv-mbed/deps/mbedtls/crypto/library/libmbedcrypto.a"; sourceTree = "<group>"; };
-		5AB6DF7A244B8F2000F4B4E0 /* libuv_link.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libuv_link.a; path = "deps/ziti-sdk-c/build-os-arch/deps/uv-mbed/deps/libuv_link.a"; sourceTree = "<group>"; };
 		5AB6DF7B244B8F2000F4B4E0 /* libmbedtls.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libmbedtls.a; path = "deps/ziti-sdk-c/build-os-arch/deps/uv-mbed/deps/mbedtls/library/libmbedtls.a"; sourceTree = "<group>"; };
 		5AB6DF7C244B8F2000F4B4E0 /* libuv_a.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libuv_a.a; path = "deps/ziti-sdk-c/build-os-arch/deps/uv-mbed/deps/libuv/libuv_a.a"; sourceTree = "<group>"; };
-		5AB6DF7D244B8F2000F4B4E0 /* libhttp-parser.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libhttp-parser.a"; path = "deps/ziti-sdk-c/build-os-arch/deps/uv-mbed/deps/libhttp-parser.a"; sourceTree = "<group>"; };
 		5AB6DFAF244B990A00F4B4E0 /* libCZiti.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libCZiti.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		5AB8308E247432C40089AF93 /* Ziti-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Ziti-Bridging-Header.h"; sourceTree = "<group>"; };
 		5AB8308F247432C40089AF93 /* ZitiError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZitiError.swift; sourceTree = "<group>"; };
@@ -250,6 +249,8 @@
 		5AF0C4102489987500CD4DAE /* ZitiClaims.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZitiClaims.swift; sourceTree = "<group>"; };
 		5AFE864127E3C56000D47A47 /* libresolv.9.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libresolv.9.tbd; path = usr/lib/libresolv.9.tbd; sourceTree = SDKROOT; };
 		5AFE864327E3C62800D47A47 /* libresolv.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libresolv.tbd; path = usr/lib/libresolv.tbd; sourceTree = SDKROOT; };
+		AA039EDF2A963C53004D3F78 /* libllhttp.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libllhttp.a; path = "deps/ziti-tunnel-sdk-c/build-macosx-arm64/vcpkg_installed/arm64-osx/debug/lib/libllhttp.a"; sourceTree = "<group>"; };
+		AA039EE12A963C9C004D3F78 /* libllhttp.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libllhttp.a; path = "deps/ziti-tunnel-sdk-c/build-iphoneos-arm64/vcpkg_installed/arm64-ios/debug/lib/libllhttp.a"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -281,6 +282,7 @@
 				5A0E4A8E24534DDE00C56DCF /* libsodium.a in Frameworks */,
 				5A0E4A8B24530E1E00C56DCF /* libziti.a in Frameworks */,
 				5A1D8AD629940BE500101BD7 /* libtlsuv.a in Frameworks */,
+				AA039EE02A963C53004D3F78 /* libllhttp.a in Frameworks */,
 				5AB6DF7F244B8F2000F4B4E0 /* libmbedx509.a in Frameworks */,
 				5AB6DF80244B8F2000F4B4E0 /* libmbedcrypto.a in Frameworks */,
 				5AB6DF82244B8F2000F4B4E0 /* libmbedtls.a in Frameworks */,
@@ -296,6 +298,7 @@
 				5AA2989825857789001F7502 /* libziti-tunnel-cbs-c.a in Frameworks */,
 				5AA2989925857789001F7502 /* liblwipcore.a in Frameworks */,
 				5A1D8AD729940C3A00101BD7 /* libtlsuv.a in Frameworks */,
+				AA039EE22A963C9C004D3F78 /* libllhttp.a in Frameworks */,
 				5AB6DFBC244BA64B00F4B4E0 /* libuv_a.a in Frameworks */,
 				5AB6DFB9244BA63F00F4B4E0 /* libmbedcrypto.a in Frameworks */,
 				5AB6DFBB244BA64700F4B4E0 /* libmbedx509.a in Frameworks */,
@@ -399,6 +402,8 @@
 		5AB6DF76244B8F2000F4B4E0 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				AA039EDF2A963C53004D3F78 /* libllhttp.a */,
+				AA039EE12A963C9C004D3F78 /* libllhttp.a */,
 				5A1D8AD529940BE500101BD7 /* libtlsuv.a */,
 				5ADAE979280F7EFD007D1DF4 /* libresolv.9.tbd */,
 				5AFE864327E3C62800D47A47 /* libresolv.tbd */,
@@ -413,13 +418,10 @@
 				5AA2989325857788001F7502 /* libziti-tunnel-sdk-c.a */,
 				5A0E4A8D24534DDE00C56DCF /* libsodium.a */,
 				5A0E4A8A24530E1E00C56DCF /* libziti.a */,
-				5AB6DF7D244B8F2000F4B4E0 /* libhttp-parser.a */,
 				5AB6DF79244B8F2000F4B4E0 /* libmbedcrypto.a */,
 				5AB6DF7B244B8F2000F4B4E0 /* libmbedtls.a */,
 				5AB6DF78244B8F2000F4B4E0 /* libmbedx509.a */,
 				5AB6DF7C244B8F2000F4B4E0 /* libuv_a.a */,
-				5AB6DF7A244B8F2000F4B4E0 /* libuv_link.a */,
-				5AB6DF77244B8F2000F4B4E0 /* libuv_mbed.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -1030,10 +1032,9 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/_deps/tlsuv-src/include",
-					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/_deps/http_parser-src",
 					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/_deps/tlsuv-src/deps/uv_link_t/include",
-					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/_deps/libuv-src/include",
 					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/_deps/ziti-sdk-c-src/includes",
+					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/vcpkg_installed/$(VCPKG_ARCH)-$(VCPKG_OS)/include",
 					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/include",
 					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/lib/ziti-tunnel/include",
 					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/lib/ziti-tunnel-cbs/include",
@@ -1043,17 +1044,26 @@
 				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/_deps/tlsuv-build",
-					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/_deps/mbedtls-build/library",
-					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/_deps/uv-mbed-build",
-					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/_deps/libuv-build",
-					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/_deps/libsodium-build/lib",
 					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/_deps/ziti-sdk-c-build/library",
 					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/lib/ziti-tunnel",
 					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/lib/ziti-tunnel-cbs",
+					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/vcpkg_installed/$(VCPKG_ARCH)-$(VCPKG_OS)/lib",
 				);
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_SWIFT_FLAGS = "";
-				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/lib/ProjectModule";
+				SWIFT_INCLUDE_PATHS = (
+					"$(SRCROOT)/lib/ProjectModule",
+					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/_deps/tlsuv-src/include",
+					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/_deps/tlsuv-src/deps/uv_link_t/include",
+					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/_deps/ziti-sdk-c-src/includes",
+					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/vcpkg_installed/$(VCPKG_ARCH)-$(VCPKG_OS)/include",
+					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/include",
+					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/lib/ziti-tunnel/include",
+					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/lib/ziti-tunnel-cbs/include",
+					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/lib/ziti-tunnel/lwip",
+					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/_deps/lwip-src/src/include",
+					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/_deps/lwip-contrib-src/ports/unix/port/include",
+				);
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 			};
 			name = Debug;
@@ -1091,10 +1101,9 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/_deps/tlsuv-src/include",
-					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/_deps/http_parser-src",
 					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/_deps/tlsuv-src/deps/uv_link_t/include",
-					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/_deps/libuv-src/include",
 					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/_deps/ziti-sdk-c-src/includes",
+					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/vcpkg_installed/$(VCPKG_ARCH)-$(VCPKG_OS)/include",
 					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/include",
 					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/lib/ziti-tunnel/include",
 					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/lib/ziti-tunnel-cbs/include",
@@ -1104,17 +1113,26 @@
 				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/_deps/tlsuv-build",
-					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/_deps/mbedtls-build/library",
-					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/_deps/uv-mbed-build",
-					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/_deps/libuv-build",
-					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/_deps/libsodium-build/lib",
 					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/_deps/ziti-sdk-c-build/library",
 					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/lib/ziti-tunnel",
 					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/lib/ziti-tunnel-cbs",
+					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/vcpkg_installed/$(VCPKG_ARCH)-$(VCPKG_OS)/lib",
 				);
 				OTHER_SWIFT_FLAGS = "";
 				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/lib/ProjectModule";
+				SWIFT_INCLUDE_PATHS = (
+					"$(SRCROOT)/lib/ProjectModule",
+					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/_deps/tlsuv-src/include",
+					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/_deps/tlsuv-src/deps/uv_link_t/include",
+					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/_deps/ziti-sdk-c-src/includes",
+					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/vcpkg_installed/$(VCPKG_ARCH)-$(VCPKG_OS)/include",
+					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/include",
+					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/lib/ziti-tunnel/include",
+					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/lib/ziti-tunnel-cbs/include",
+					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/lib/ziti-tunnel/lwip",
+					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/_deps/lwip-src/src/include",
+					"$(PROJECT_DIR)/deps/ziti-tunnel-sdk-c/build-$(PLATFORM_NAME)-$(CURRENT_ARCH)/_deps/lwip-contrib-src/ports/unix/port/include",
+				);
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 			};
 			name = Release;

--- a/Configs/workspace-settings.xcconfig
+++ b/Configs/workspace-settings.xcconfig
@@ -3,5 +3,10 @@
 
 DEVELOPMENT_TEAM = XXXXXXXXXX
 ORGANIZATION_PREFIX = org.openziti
+VCPKG_ARCH[arch=arm64] = arm64
+VCPKG_ARCH[arch=x86_64] = x64
+VCPKG_OS[sdk=iphoneos*] = ios
+VCPKG_OS[sdk=iphonesimulator*] = iphonesimulator
+VCPKG_OS[sdk=macosx*] = osx
 
 #include? "workspace-settings-overrides.xcconfig"

--- a/build_all.sh
+++ b/build_all.sh
@@ -22,7 +22,9 @@ function build_tsdk {
    rm -rf ./deps/ziti-tunnel-sdk-c/${name}
 
    cmake -DCMAKE_BUILD_TYPE=${CONFIGURATION} \
+      -DTLSUV_TLSLIB=mbedtls \
       -DMBEDTLS_FATAL_WARNINGS:BOOL=OFF -DEXCLUDE_PROGRAMS=ON \
+      -DZITI_TUNNEL_BUILD_TESTS=OFF \
       -DCMAKE_TOOLCHAIN_FILE="${toolchain}" \
       -S ./deps/ziti-tunnel-sdk-c -B ./deps/ziti-tunnel-sdk-c/${name}
 
@@ -37,6 +39,10 @@ function build_tsdk {
       exit 1
    fi
 }
+
+if ! command -v xcpretty > /dev/null; then
+  xcpretty() { echo "install xcpretty for more legible xcodebuild output"; cat; }
+fi
 
 function build_cziti {
    scheme=$1

--- a/deps/toolchains/iOS-Simulator-arm64.cmake
+++ b/deps/toolchains/iOS-Simulator-arm64.cmake
@@ -1,21 +1,18 @@
-# build-iphoneos-arm64
+# build-iphonesimulator-arm64
 
 set(CMAKE_SYSTEM_NAME iOS)
 set(CMAKE_SYSTEM_PROCESSOR arm64)
+set(CMAKE_OSX_ARCHITECTURES "arm64" CACHE STRING "The list of target architectures to build")
 
-SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -arch arm64")
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -arch arm64")
-
-# for libsodium
-set(triple arm-apple-darwin10)
 execute_process(COMMAND /usr/bin/xcrun -sdk iphonesimulator --show-sdk-path
                 OUTPUT_VARIABLE CMAKE_OSX_SYSROOT
                 OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-set(ENV{CFLAGS} "-arch arm64 -isysroot ${CMAKE_OSX_SYSROOT}")
-set(ENV{LDFLAGS} "-arch arm64 -isysroot ${CMAKE_OSX_SYSROOT}")
 
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+
+set(VCPKG_OVERLAY_TRIPLETS ${PROJECT_SOURCE_DIR}/../vcpkg-triplets)
+set(VCPKG_TARGET_TRIPLET arm64-iphonesimulator)
+include($ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake)

--- a/deps/toolchains/iOS-Simulator-x86_64.cmake
+++ b/deps/toolchains/iOS-Simulator-x86_64.cmake
@@ -2,20 +2,17 @@
 
 set(CMAKE_SYSTEM_NAME iOS)
 set(CMAKE_SYSTEM_PROCESSOR x86_64)
+set(CMAKE_OSX_ARCHITECTURES "x86_64" CACHE STRING "The list of target architectures to build")
 
-SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -arch x86_64")
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -arch x86_64")
-
-# for libsodium
-set(triple x86_64-apple-darwin10)
 execute_process(COMMAND /usr/bin/xcrun -sdk iphonesimulator --show-sdk-path
                 OUTPUT_VARIABLE CMAKE_OSX_SYSROOT
                 OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-set(ENV{CFLAGS} "-arch x86_64 -isysroot ${CMAKE_OSX_SYSROOT}")
-set(ENV{LDFLAGS} "-arch x86_64 -isysroot ${CMAKE_OSX_SYSROOT}")
 
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+
+set(VCPKG_OVERLAY_TRIPLETS ${PROJECT_SOURCE_DIR}/../vcpkg-triplets)
+set(VCPKG_TARGET_TRIPLET x64-iphonesimulator)
+include($ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake)

--- a/deps/toolchains/iOS-arm64.cmake
+++ b/deps/toolchains/iOS-arm64.cmake
@@ -2,20 +2,12 @@
 
 set(CMAKE_SYSTEM_NAME iOS)
 set(CMAKE_SYSTEM_PROCESSOR arm64)
-
-SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -arch arm64")
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -arch arm64")
-
-# for libsodium
-set(triple arm-apple-darwin10)
-execute_process(COMMAND /usr/bin/xcrun -sdk iphoneos --show-sdk-path
-                OUTPUT_VARIABLE CMAKE_OSX_SYSROOT
-                OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-set(ENV{CFLAGS} "-arch arm64 -isysroot ${CMAKE_OSX_SYSROOT}")
-set(ENV{LDFLAGS} "-arch arm64 -isysroot ${CMAKE_OSX_SYSROOT}")
+set(CMAKE_OSX_ARCHITECTURES "arm64" CACHE STRING "The list of target architectures to build")
 
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+
+set(VCPKG_TARGET_TRIPLET arm64-ios)
+include($ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake)

--- a/deps/toolchains/macOS-arm64.cmake
+++ b/deps/toolchains/macOS-arm64.cmake
@@ -2,22 +2,12 @@
 
 set(CMAKE_SYSTEM_NAME Darwin)
 set(CMAKE_SYSTEM_PROCESSOR arm64)
-
-set(ZITI_BUILD_TESTS OFF CACHE BOOL "" FORCE)
-
-SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -arch arm64")
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -arch arm64")
-
-# for libsodium
-set(triple arm64-apple-macos11)
-execute_process(COMMAND /usr/bin/xcrun -sdk macosx --show-sdk-path
-                OUTPUT_VARIABLE CMAKE_OSX_SYSROOT
-                OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-set(ENV{CFLAGS} "-arch arm64 -isysroot ${CMAKE_OSX_SYSROOT}")
-set(ENV{LDFLAGS} "-arch arm64 -isysroot ${CMAKE_OSX_SYSROOT}")
+set(CMAKE_OSX_ARCHITECTURES "arm64" CACHE STRING "The list of target architectures to build")
 
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+
+set(VCPKG_TARGET_TRIPLET arm64-osx)
+include($ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake)

--- a/deps/toolchains/macOS-x86_64.cmake
+++ b/deps/toolchains/macOS-x86_64.cmake
@@ -2,22 +2,12 @@
 
 set(CMAKE_SYSTEM_NAME Darwin)
 set(CMAKE_SYSTEM_PROCESSOR x86_64)
-
-set(ZITI_BUILD_TESTS OFF CACHE BOOL "" FORCE)
-
-SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -arch x86_64")
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -arch x86_64")
-
-# for libsodium
-set(triple x86_64-apple-macos11)
-execute_process(COMMAND /usr/bin/xcrun -sdk macosx --show-sdk-path
-                OUTPUT_VARIABLE CMAKE_OSX_SYSROOT
-                OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-set(ENV{CFLAGS} "-arch x86_64 -isysroot ${CMAKE_OSX_SYSROOT}")
-set(ENV{LDFLAGS} "-arch x86_64 -isysroot ${CMAKE_OSX_SYSROOT}")
+set(CMAKE_OSX_ARCHITECTURES "x86_64" CACHE STRING "The list of target architectures to build")
 
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+
+set(VCPKG_TARGET_TRIPLET x64-osx)
+include($ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake)

--- a/deps/vcpkg-triplets/arm64-iphonesimulator.cmake
+++ b/deps/vcpkg-triplets/arm64-iphonesimulator.cmake
@@ -1,0 +1,2 @@
+include($ENV{VCPKG_ROOT}/triplets/community/arm64-ios.cmake)
+set(VCPKG_OSX_SYSROOT iphonesimulator)

--- a/deps/vcpkg-triplets/x64-iphonesimulator.cmake
+++ b/deps/vcpkg-triplets/x64-iphonesimulator.cmake
@@ -1,0 +1,2 @@
+include($ENV{VCPKG_ROOT}/triplets/community/x64-ios.cmake)
+set(VCPKG_OSX_SYSROOT iphonesimulator)

--- a/lib/Ziti.swift
+++ b/lib/Ziti.swift
@@ -416,19 +416,33 @@ import CZitiPrivate
         // setup TLS
         let caLen = (id.ca == nil ? 0 : id.ca!.count + 1)
         tls = default_tls_context(id.ca?.cString(using: .utf8), caLen)
-        let tlsStat = tls?.pointee.api.pointee.set_own_cert(tls?.pointee.ctx,
-                                              certPEM.cString(using: .utf8),
-                                              certPEM.count + 1,
-                                              privKeyPEM.cString(using: .utf8),
-                                              privKeyPEM.count + 1)
+        
+        var tlsKey:tlsuv_private_key_t?
+        var tlsStat = tls?.pointee.api.pointee.load_key(&tlsKey, privKeyPEM.cString(using: .utf8), privKeyPEM.count + 1)
         guard tlsStat == 0 else {
-            let errStr = "unable to configure TLS, error code: \(tlsStat ?? 0)"
+            let errStr = "unable to load TLS private key, error code: \(tlsStat ?? 0)"
             log.error(errStr)
             initCallback(ZitiError(errStr, errorCode: Int(tlsStat ?? 0)))
             return
         }
-                
-        // remove compiler warning on cztAPI memory living past the inti call
+
+        tlsStat = tls?.pointee.api.pointee.set_own_cert(tls?.pointee.ctx, certPEM.cString(using: .utf8), certPEM.count + 1)
+        guard tlsStat == 0 else {
+            let errStr = "unable to configure TLS certificate, error code: \(tlsStat ?? 0)"
+            log.error(errStr)
+            initCallback(ZitiError(errStr, errorCode: Int(tlsStat ?? 0)))
+            return
+        }
+        
+        tlsStat = tls?.pointee.api.pointee.set_own_key(tls?.pointee.ctx, tlsKey)
+        guard tlsStat == 0 else {
+            let errStr = "unable to configure TLS private key, error code: \(tlsStat ?? 0)"
+            log.error(errStr)
+            initCallback(ZitiError(errStr, errorCode: Int(tlsStat ?? 0)))
+            return
+        }
+
+        // remove compiler warning on cztAPI memory living past the init call
         ctrlPtr = UnsafeMutablePointer<Int8>.allocate(capacity: id.ztAPI.count + 1)
         ctrlPtr!.initialize(from: cztAPI, count: id.ztAPI.count + 1)
         

--- a/make_dist.sh
+++ b/make_dist.sh
@@ -37,7 +37,7 @@ xcframework_args=""
 if [ "${FOR}" = "All" ] || [ "${FOR}" = "iOS" ] ; then
    xcframework_args+=" -library ${BUILD_DIR}/${CONFIGURATION}-iphoneos/${LIB_NAME}"
    xcframework_args+=" -headers ${DERIVED_BUILD_DIR}/${CONFIGURATION}-iphoneos/CZiti-iOS.build/DerivedSources"
-   xcframework_args+=" -library ${BUILD_DIR}/${CONFIGURATION}-iphonesimulator/${LIB_NAME}" \
+   xcframework_args+=" -library ${BUILD_DIR}/${CONFIGURATION}-iphonesimulator/${LIB_NAME}"
    xcframework_args+=" -headers ${DERIVED_BUILD_DIR}/${CONFIGURATION}-iphonesimulator/CZiti-iOS.build/DerivedSources"
 fi
 
@@ -45,7 +45,7 @@ fi
 # macOS
 #
 if [ "${FOR}" = "All" ] || [ "${FOR}" = "macOS" ] ; then
-   xcframework_args+=" -library ${BUILD_DIR}/${CONFIGURATION}/${LIB_NAME}" \
+   xcframework_args+=" -library ${BUILD_DIR}/${CONFIGURATION}/${LIB_NAME}"
    xcframework_args+=" -headers ${DERIVED_BUILD_DIR}/${CONFIGURATION}/CZiti-macOS.build/DerivedSources"
 fi
 


### PR DESCRIPTION
also use vcpkg when building tsdk. we'll soon update the tsdk repo's workflows to produce these builds (specifically iOS and simulator), but for now this lets us move forward.