### PR TITLE
get release with gh cli

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
         VERS: ${{ steps.get_release.outputs.tag_name }}
         CHKSM: ${{ steps.calc_checksum.outputs.checksum }}
       run: |
-        echo "VERS=${VERS}; CHKSM=${CHKSM}
+        echo "VERS=${VERS}; CHKSM=${CHKSM}"
         sed "/let version = \"/s/.*/let version = \"${VERS}\"/; /let checksum = \"/s/.*/let checksum = \"${CHKSM}\"/" Package.swift > Package.swift.next
         cat Package.swift.next
         mv Package.swift.next Package.swift

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,20 +13,23 @@ jobs:
 
     - name: Get Release
       id: get_release
-      uses: bruceadams/get-release@v1.3.2
+      run: |
+        url=$(gh release view --json url --jq .url)
+        echo "url=${url}" | tee -a $GITHUB_OUTPUT
+        tag_name=$(gh release view --json tagName --jq .tagName)
+        echo "tag_name=${tag_name}" | tee -a $GITHUB_OUTPUT
       env:
         GITHUB_TOKEN: ${{ github.token }}
 
     - name: Download xcframework
-      run: curl ${{ github.server_url }}/${{ github.repository }}/releases/download/${{ steps.get_release.outputs.tag_name }}/CZiti.xcframework.zip -L -o CZiti.xcframework.zip
+      run: curl ${{ steps.get_release.outputs.url }}/CZiti.xcframework.zip -LO
 
     - name: Compute Checksum
       id: calc_checksum
       run: |
         # checksum=$(swift package compute-checksum ./CZiti.xcframework.zip)
         checksum=$(shasum -a 256 ./CZiti.xcframework.zip | cut -d " " -f1)
-        echo "checksum: ${checksum}"
-        echo "checksum=${checksum}" >> $GITHUB_OUTPUT
+        echo "checksum=${checksum}" | tee -a $GITHUB_OUTPUT
 
     - name: Checkout Distribution Project
       uses: actions/checkout@v3
@@ -38,7 +41,7 @@ jobs:
         VERS: ${{ steps.get_release.outputs.tag_name }}
         CHKSM: ${{ steps.calc_checksum.outputs.checksum }}
       run: |
-        echo "VERS=${VERS}; CHKSM=${CHKSM}"
+        echo "VERS=${VERS}; CHKSM=${CHKSM}
         sed "/let version = \"/s/.*/let version = \"${VERS}\"/; /let checksum = \"/s/.*/let checksum = \"${CHKSM}\"/" Package.swift > Package.swift.next
         cat Package.swift.next
         mv Package.swift.next Package.swift
@@ -80,7 +83,9 @@ jobs:
 
     - name: Get Release
       id: get_release
-      uses: bruceadams/get-release@v1.3.2
+      run: |
+        tag_name=$(gh release view --json tagName --jq .tagName)
+        echo "tag_name=${tag_name}" | tee -a $GITHUB_OUTPUT
       env:
         GITHUB_TOKEN: ${{ github.token }}
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Ziggy using the ziti-sdk-swift](https://raw.githubusercontent.com/openziti/branding/main/images/banners/Swift.jpg)
 
 # Ziti SDK for Swift
-![Build Status](https://github.com/openziti/ziti-sdk-swift/workflows/CI/badge.svg?branch=master)
+![Build Status](https://github.com/openziti/ziti-sdk-swift/workflows/CI/badge.svg?branch=main)
 
 An SDK for accessing Ziti from macOS and iOS applications using the Swift programming language.
 


### PR DESCRIPTION
The [most recent run of the publish workflow](https://github.com/openziti/ziti-sdk-swift/actions/runs/6123428821) failed to get the release info using the bruceadams/get-release action. Also see https://github.com/bruceadams/get-release/issues/30.

This PR works around whatever the issue is by using the GitHub cli.