### PR TITLE
Call initCallback on first event, and include ca bundle in api events.

### DIFF
--- a/lib/Ziti.swift
+++ b/lib/Ziti.swift
@@ -40,6 +40,8 @@ import CZitiPrivate
     
     /// Opaque reference to Ziti SDK C context
     public var ztx:OpaquePointer?
+    /// received first event from C sdk.
+    private var eventReceived = false
     
     /// Access to the `ZitiTunnel` managing this instance (if applicable)
     public weak var zitiTunnel:ZitiTunnel?
@@ -905,8 +907,8 @@ import CZitiPrivate
         }
         
         // first time..
-        if let ztx = ztx, mySelf.ztx == nil {
-            mySelf.ztx = ztx
+        if let ztx = ztx, !mySelf.eventReceived {
+            mySelf.eventReceived = true
             Ziti.postureContexts[ztx] = mySelf
             mySelf.initCallback?(nil)
         }

--- a/lib/ZitiTunnelEvent.swift
+++ b/lib/ZitiTunnelEvent.swift
@@ -214,15 +214,20 @@ import CZitiPrivate
     /// New controller address
     public var newControllerAddress:String = ""
     
+    /// New ca bundle
+    public var newCaBundle = ""
+    
     init(_ ziti:Ziti, _ evt:UnsafePointer<api_event>) {
         super.init(ziti)
         self.newControllerAddress = toStr(evt.pointee.new_ctrl_address)
+        self.newCaBundle = toStr(evt.pointee.new_ca_bundle)
     }
     
     /// Debug description
     /// - returns: String containing debug description of this event
     public override var debugDescription: String {
         return super.debugDescription + "\n" +
-            "   newControllerAddress: \(newControllerAddress)"
+            "   newControllerAddress: \(newControllerAddress)\n" +
+            "   newCaBundle: \(newCaBundle)"
     }
 }


### PR DESCRIPTION
fixes #201 