### PR TITLE
conditionally update ctrl address and ca on api events

### DIFF
--- a/lib/Ziti.swift
+++ b/lib/Ziti.swift
@@ -916,8 +916,14 @@ import CZitiPrivate
         // create and send the event...
         let event = ZitiEvent(mySelf, cEvent)
         
+        // update ourself
         if event.type == ZitiEvent.EventType.ApiEvent {
-            mySelf.id.ztAPI = event.apiEvent!.newControllerAddress
+            if !event.apiEvent!.newControllerAddress.isEmpty {
+                mySelf.id.ztAPI = event.apiEvent!.newControllerAddress
+            }
+            if !event.apiEvent!.newCaBundle.isEmpty {
+                mySelf.id.ca = event.apiEvent!.newCaBundle
+            }
         }
         
         mySelf.eventCallbacksLock.lock()

--- a/lib/ZitiEvent.swift
+++ b/lib/ZitiEvent.swift
@@ -182,6 +182,7 @@ import CZitiPrivate
         
         /// New controller address
         @objc public let newControllerAddress:String
+        @objc public let newCaBundle:String
         init( _ cEvent:ziti_api_event) {
             var str = ""
             if let cStr = cEvent.new_ctrl_address {
@@ -189,8 +190,14 @@ import CZitiPrivate
             }
             if !str.starts(with: "https://") {
                 str.insert(contentsOf: "https://", at: str.startIndex)
-             }
+            }
             newControllerAddress = str
+            
+            var caStr = ""
+            if let cStr = cEvent.new_ca_bundle {
+                caStr = String(cString: cStr)
+            }
+            newCaBundle = caStr
         }
     }
     

--- a/lib/ZitiTunnel.swift
+++ b/lib/ZitiTunnel.swift
@@ -336,7 +336,14 @@ public class ZitiTunnel : NSObject, ZitiUnretained {
         case TunnelEvents.APIEvent.rawValue:
             var cApiEvent = UnsafeRawPointer(cEvent).bindMemory(to: api_event.self, capacity: 1)
             let event = ZitiTunnelApiEvent(ziti, cApiEvent)
-            ziti.id.ztAPI = event.newControllerAddress
+            // update ourself with event info
+            if !event.newControllerAddress.isEmpty {
+                ziti.id.ztAPI = event.newControllerAddress
+            }
+            if !event.newCaBundle.isEmpty {
+                ziti.id.ca = event.newCaBundle
+            }
+            // pass event to application
             mySelf.tunnelProvider?.tunnelEventCallback(event)
         default:
             log.warn("Unrecognized event type \(cEvent.pointee.event_type.rawValue)")

--- a/lib/ZitiTunnelEvent.swift
+++ b/lib/ZitiTunnelEvent.swift
@@ -215,7 +215,7 @@ import CZitiPrivate
     public var newControllerAddress:String = ""
     
     /// New ca bundle
-    public var newCaBundle = ""
+    public var newCaBundle:String = ""
     
     init(_ ziti:Ziti, _ evt:UnsafePointer<api_event>) {
         super.init(ziti)


### PR DESCRIPTION
only update ziti context with populated values from api event 