### PR TITLE
initialize ziti sdk log

### DIFF
--- a/lib/Ziti-Bridging-Header.h
+++ b/lib/Ziti-Bridging-Header.h
@@ -22,6 +22,7 @@ limitations under the License.
 extern const char** ziti_all_configs;
 extern tls_context *default_tls_context(const char *ca, size_t ca_len);
 
+void ziti_log_init_wrapper(uv_loop_t *loop);
 void set_tunnel_logger(void);
 
 typedef int (*ziti_printer_cb_wrapper)(void *ctx, const char *msg);

--- a/lib/Ziti.swift
+++ b/lib/Ziti.swift
@@ -448,7 +448,9 @@ import CZitiPrivate
         if (caPEMPtr != nil) {
             caPEMPtr!.deallocate()
         }
-
+        
+        ziti_log_init_wrapper(loop)
+        
         var zitiOpts = ziti_options(config: nil,
                                 disabled: id.startDisabled ?? false,
                                 config_types: ziti_all_configs,

--- a/lib/ZitiEnroller.swift
+++ b/lib/ZitiEnroller.swift
@@ -22,6 +22,14 @@ import CZitiPrivate
 @objc public class ZitiEnroller : NSObject, ZitiUnretained {
     private static let log = ZitiLog(ZitiEnroller.self)
     private let log = ZitiEnroller.log
+    /// use the same loop for all enrollments, otherwise the logger's loop will be invalid after the first enrollment.
+    private static var loop: UnsafeMutablePointer<uv_loop_t> = {
+        let l = UnsafeMutablePointer<uv_loop_t>.allocate(capacity: 1)
+        l.initialize(to: uv_loop_t())
+        uv_loop_init(l)
+        ziti_log_init_wrapper(l)
+        return l
+    }()
     
     /**
      * Class representing response to successful enrollment attempt
@@ -139,19 +147,9 @@ import CZitiPrivate
      *      - cb: callback called indicating status of enrollment attempt
      */
     @objc public func enroll(privatePem:String, cb:@escaping EnrollmentCallback) {
-        var loop = uv_loop_t()
+        self.enroll(withLoop: ZitiEnroller.loop, privatePem: privatePem, cb: cb)
         
-        let initStatus = uv_loop_init(&loop)
-        guard initStatus == 0 else {
-            let errStr = String(cString: uv_strerror(initStatus))
-            log.error(errStr)
-            cb(nil, nil, ZitiError(errStr, errorCode: Int(initStatus)))
-            return
-        }
-        ziti_log_init_wrapper(&loop)
-        self.enroll(withLoop: &loop, privatePem: privatePem, cb: cb)
-        
-        let runStatus = uv_run(&loop, UV_RUN_DEFAULT)
+        let runStatus = uv_run(ZitiEnroller.loop, UV_RUN_DEFAULT)
         guard runStatus == 0 else {
             let errStr = String(cString: uv_strerror(runStatus))
             log.error(errStr)

--- a/lib/ZitiEnroller.swift
+++ b/lib/ZitiEnroller.swift
@@ -148,7 +148,7 @@ import CZitiPrivate
             cb(nil, nil, ZitiError(errStr, errorCode: Int(initStatus)))
             return
         }
-        
+        ziti_log_init_wrapper(&loop)
         self.enroll(withLoop: &loop, privatePem: privatePem, cb: cb)
         
         let runStatus = uv_run(&loop, UV_RUN_DEFAULT)

--- a/lib/ziti.c
+++ b/lib/ziti.c
@@ -34,6 +34,12 @@ ZITI_FUNC extern void
 ziti_logger(int level, const char *module, const char *file, unsigned int line, const char *func,
             const char *fmt, ...);
 
+// including ziti_log.h throws a fit.
+extern void ziti_log_init(uv_loop_t *loop, int level, void *logfn);
+void ziti_log_init_wrapper(uv_loop_t *loop) {
+    ziti_log_init(loop, -1, NULL);
+}
+
 void set_tunnel_logger(void) {
     ziti_tunnel_set_logger(ziti_logger);
 }


### PR DESCRIPTION
log initialization used to be done by `ziti_init_opts`, but we now initialize the sdk with `ziti_context_set_options` / `ziti_context_run` so the log needs to be explicitly initialized.