### PR TITLE
Bump TSDK to v0.22.13

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,7 +32,7 @@ jobs:
 
     - uses: lukka/run-vcpkg@v10
       with:
-        vcpkgGitCommitId: '19af97cba8ca48474e4ad15a24ed50271a9ecdac'
+        vcpkgGitCommitId: 'f6a5d4e8eb7476b8d7fc12a56dff300c1c986131'
 
     - name: ${{ matrix.spec.name }}
       env:


### PR DESCRIPTION
tsdk 0.22.13 improves performance by resolving hostnames in worker threads
also pulls in ziti-sdk-c 0.35.5 for rebind fixes