### PR TITLE
enable prerelease builds

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,9 +1,9 @@
 name: CI
 on:
   pull_request:
-    branches: [ main ]
-  push:
-    branches: [ main ]
+    branches:
+      - main
+      - alpha
 permissions:
   contents: write
 
@@ -110,7 +110,7 @@ jobs:
   draft-release:
     runs-on: ubuntu-latest
     needs: [ build-cziti ]
-    if: github.event_name == 'push' && github.ref  == 'refs/heads/main'
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/alpha')
     steps:
     - name: Checkout Project
       uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,11 @@ jobs:
       run: |
         tag_name=$(gh release view --json tagName --jq .tagName)
         echo "tag_name=${tag_name}" | tee -a $GITHUB_OUTPUT
+        tag_suffix=$(echo -n "${tag_name}" | cut -s -d '-' -f 2-)
+        dist_branch=$(echo -n ${tag_suffix:-main})
+        echo "dist_branch=${dist_branch}" | tee -a $GITHUB_OUTPUT
+        gh_pages_branch="gh-pages${tag_suffix:+-$tag_suffix}"
+        echo "gh_pages_branch=${gh_pages_branch}" | tee -a $GITHUB_OUTPUT
       env:
         GITHUB_TOKEN: ${{ github.token }}
 
@@ -35,6 +40,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: openziti/ziti-sdk-swift-dist
+        ref: ${{ steps.get_release.outputs.dist_branch }}
 
     - name: Edit Package.swift
       env:
@@ -95,3 +101,4 @@ jobs:
       uses: JamesIves/github-pages-deploy-action@v4
       with:
         folder: docs
+        branch: ${{ steps.get_release.outputs.gh_pages_branch }}


### PR DESCRIPTION
releases that are tagged with a label (e.g. 0.1.2-label) will be published to the `label` branch of https://github.com/openziti/ziti-sdk-swift-dist, and the docs will be pushed to the `gh-pages-label` branch of this repo.