### PR TITLE
Improve battery consumption on iOS

### DIFF
--- a/lib/Ziti.swift
+++ b/lib/Ziti.swift
@@ -408,7 +408,7 @@ import CZitiPrivate
         #if os(macOS)
             let refresh_interval = 15
         #else
-            let refresh_interval = 30
+            let refresh_interval = 90
         #endif
         
         // convert key and id info to char * types that ziti-sdk-c can use.


### PR DESCRIPTION
Increases the service poll interval. We were asking for a 30s refresh interval, but the actual refresh was 10s due to a bug that was fixed in tsdk@1.2.6.

The 90s refresh interval allowed my ZME to stay at 1% or less battery consumption after running for 24 hours.